### PR TITLE
feat(plan): generate repro.md from issue description (text-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ AutoRepro is a developer tools project that transforms issue descriptions into c
 The current MVP scope includes three core commands:
 - **scan**: Detect languages/frameworks from file pointers (✅ implemented)
 - **init**: Create a developer container (✅ implemented)
-- **plan**: Derive an execution plan from issue description (coming soon)
+- **plan**: Derive an execution plan from issue description (✅ implemented)
 
 The project targets multilingualism (initially Python/JS/Go) and emphasizes simplicity, transparency, and automated testing. The ultimate goal is to produce tests that automatically fail and open Draft PRs containing them, improving contribution quality and speeding up maintenance on GitHub.
 
@@ -45,6 +45,9 @@ autorepro scan
 
 # Create a devcontainer.json file
 autorepro init
+
+# Generate a reproduction plan from issue description
+autorepro plan --desc "tests failing with pytest"
 ```
 
 ### Scan Command
@@ -124,13 +127,61 @@ Wrote devcontainer to dev/devcontainer.json
 - `--force`: Overwrite existing devcontainer.json file
 - `--out PATH`: Custom output path (default: .devcontainer/devcontainer.json)
 
+### Plan Command
+
+Generates structured reproduction plans from issue descriptions, combining keyword analysis with project language detection to suggest prioritized commands.
+
+```bash
+# Generate plan from description
+$ autorepro plan --desc "pytest tests failing on CI"
+repro.md
+
+# Generate plan from file
+$ autorepro plan --file issue.txt
+repro.md
+
+# Custom output path
+$ autorepro plan --desc "npm test issues" --out my_plan.md
+my_plan.md
+
+# Overwrite existing plan
+$ autorepro plan --desc "build failing" --force
+repro.md
+
+# Limit number of suggested commands
+$ autorepro plan --desc "tests timeout" --max 3
+repro.md
+
+# JSON format (produces md with notice)
+$ autorepro plan --desc "linting errors" --format json
+json output not implemented yet; generating md
+repro.md
+```
+
+**Status:** `plan` is implemented with intelligent command suggestions and markdown output.
+
+**Plan Behavior:**
+- **Input options**: `--desc "text"` or `--file path.txt` (mutually exclusive, one required)
+- **Language detection**: Uses `scan` results to weight command suggestions
+- **Keyword extraction**: Filters stopwords while preserving dev terms (pytest, npm, tox, etc.)
+- **Command scoring**: Combines language priors + keyword matches for ranking
+- **Structured output**: Title, Assumptions, Environment/Needs, Steps table, Next Steps
+
+**Options:**
+- `--desc TEXT`: Issue description text
+- `--file PATH`: Path to file containing issue description
+- `--out PATH`: Output path (default: repro.md)
+- `--force`: Overwrite existing output file
+- `--max N`: Maximum suggested commands (default: 5)
+- `--format md|json`: Output format (MVP: md only, json shows notice)
+
 ## Exit Codes
 
 AutoRepro uses standard exit codes to indicate success or failure:
 
 - **0**: Success (including "already exists" and overwrite operations)
 - **1**: Unexpected I/O or permission errors
-- **2**: Misuse (e.g., `--out` points to a directory)
+- **2**: Misuse (e.g., `--out` points to a directory, missing --desc/--file)
 
 ## Development
 

--- a/autorepro/planner.py
+++ b/autorepro/planner.py
@@ -1,0 +1,347 @@
+"""AutoRepro planner module for generating reproduction plans from issue descriptions."""
+
+import re
+from typing import Any
+
+
+def normalize(text: str) -> str:
+    """
+    Normalize text by lowercasing and removing light punctuation noise.
+
+    Args:
+        text: Raw input text to normalize
+
+    Returns:
+        Normalized text with consistent whitespace and minimal punctuation
+    """
+    if not text:
+        return ""
+
+    # Convert to lowercase
+    text = text.lower()
+
+    # Remove markdown noise and light punctuation
+    # Remove: # * ` ~ " ' < > [ ] ( ) { }
+    noise_chars = r'[#*`~"\'<>\[\](){}]'
+    text = re.sub(noise_chars, " ", text)
+
+    # Strip leading/trailing whitespace and collapse internal whitespace
+    text = re.sub(r"\s+", " ", text.strip())
+
+    return text
+
+
+def extract_keywords(text: str) -> set[str]:
+    """
+    Extract keywords from normalized text using light heuristics.
+
+    Args:
+        text: Input text to extract keywords from
+
+    Returns:
+        Set of relevant keywords, filtered for stopwords and length
+    """
+    if not text:
+        return set()
+
+    # Basic English stopwords
+    stopwords = {
+        "the",
+        "and",
+        "or",
+        "but",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "of",
+        "with",
+        "by",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+        "will",
+        "would",
+        "could",
+        "should",
+        "can",
+        "may",
+        "this",
+        "that",
+        "these",
+        "those",
+        "i",
+        "you",
+        "he",
+        "she",
+        "it",
+        "we",
+        "they",
+        "me",
+        "him",
+        "her",
+        "us",
+        "them",
+        "my",
+        "your",
+        "his",
+        "its",
+        "our",
+        "their",
+        "a",
+        "an",
+        "as",
+        "if",
+        "so",
+        "no",
+        "not",
+        "all",
+        "any",
+        "some",
+        "from",
+        "up",
+        "out",
+        "down",
+        "off",
+        "over",
+        "under",
+    }
+
+    # Developer-shorthand terms to preserve
+    dev_terms = {
+        "pytest",
+        "tox",
+        "jest",
+        "vitest",
+        "playwright",
+        "npm",
+        "yarn",
+        "pnpm",
+        "go",
+        "gotest",
+        "make",
+        "electron",
+        "node",
+        "python",
+        "pyproject",
+        "requirements",
+        "package",
+        "json",
+        "test",
+        "tests",
+        "testing",
+        "ci",
+        "cd",
+        "build",
+        "run",
+        "install",
+        "setup",
+        "config",
+        "lint",
+        "format",
+    }
+
+    # Tokenize on non-alphanumeric characters
+    tokens = re.findall(r"\b[a-z0-9]+\b", text.lower())
+
+    # Filter tokens: keep if length >= 2 and not a stopword, or if it's a dev term
+    keywords = set()
+    for token in tokens:
+        if len(token) >= 2 and (token not in stopwords or token in dev_terms):
+            keywords.add(token)
+
+    return keywords
+
+
+def suggest_commands(keywords: set[str], detected_langs: list[str]) -> list[tuple[str, int, str]]:
+    """
+    Suggest commands based on keywords and detected languages.
+
+    Args:
+        keywords: Set of extracted keywords
+        detected_langs: List of detected languages from detect_languages()
+
+    Returns:
+        List of (command, score, rationale) tuples sorted by descending score
+    """
+    suggestions = []
+
+    # Language-specific command mappings with base scores
+    lang_commands = {
+        "python": [
+            ("pytest -q", 20, "Python testing with pytest"),
+            ("python -m pytest -q", 18, "Python testing via module"),
+            ("tox -q", 15, "Python multi-environment testing"),
+        ],
+        "node": [
+            ("npm test -s", 20, "Node.js npm test runner"),
+            ("npx jest --silent", 18, "Jest testing framework"),
+            ("npx vitest run", 15, "Vitest testing framework"),
+            ("npx playwright test", 12, "Playwright end-to-end testing"),
+        ],
+        "javascript": [
+            ("npm test -s", 20, "JavaScript npm test runner"),
+            ("npx jest --silent", 18, "Jest testing framework"),
+            ("npx vitest run", 15, "Vitest testing framework"),
+        ],
+        "go": [
+            ("go test ./...", 20, "Go testing all packages"),
+            ("go test -v ./...", 15, "Go verbose testing"),
+        ],
+    }
+
+    # Keyword-specific boost mappings
+    keyword_boosts = {
+        "pytest": {"pytest -q": 10, "python -m pytest -q": 8},
+        "jest": {"npx jest --silent": 10},
+        "vitest": {"npx vitest run": 10},
+        "playwright": {"npx playwright test": 10},
+        "tox": {"tox -q": 10},
+        "test": {"pytest -q": 5, "npm test -s": 5, "go test ./...": 5},
+        "tests": {"pytest -q": 5, "npm test -s": 5, "go test ./...": 5},
+        "testing": {"pytest -q": 3, "npm test -s": 3, "go test ./...": 3},
+        "ci": {"pytest -q": 3, "npm test -s": 3, "go test ./...": 3, "tox -q": 5},
+        "npm": {"npm test -s": 8},
+        "yarn": {"npm test -s": 5},  # fallback to npm
+        "pnpm": {"npm test -s": 5},  # fallback to npm
+        "python": {"pytest -q": 5, "python -m pytest -q": 5},
+        "node": {"npm test -s": 5, "npx jest --silent": 3},
+        "go": {"go test ./...": 8},
+        "build": {"npm test -s": 2, "go test ./...": 2},
+        "install": {"npm test -s": 1, "pytest -q": 1},
+    }
+
+    # Collect all unique commands with base scores
+    command_scores: dict[str, dict[str, Any]] = {}
+
+    # Add language-based commands
+    for lang in detected_langs:
+        lang_key = lang.lower()
+        if lang_key in lang_commands:
+            for cmd, base_score, _ in lang_commands[lang_key]:
+                if cmd not in command_scores:
+                    command_scores[cmd] = {
+                        "score": base_score,
+                        "rationale_parts": [f"detected {lang}"],
+                    }
+                else:
+                    command_scores[cmd]["score"] += base_score // 2
+                    command_scores[cmd]["rationale_parts"].append(f"detected {lang}")
+
+    # Apply keyword boosts
+    for keyword in keywords:
+        if keyword in keyword_boosts:
+            for cmd, boost in keyword_boosts[keyword].items():
+                if cmd in command_scores:
+                    command_scores[cmd]["score"] += boost
+                    command_scores[cmd]["rationale_parts"].append(f'keyword "{keyword}"')
+                else:
+                    # Add new command based on keyword alone
+                    command_scores[cmd] = {
+                        "score": boost,
+                        "rationale_parts": [f'keyword "{keyword}"'],
+                    }
+
+    # Add conservative defaults if no strong signals
+    if not command_scores:
+        command_scores["pytest -q"] = {"score": 5, "rationale_parts": ["conservative default"]}
+        command_scores["npm test -s"] = {"score": 5, "rationale_parts": ["conservative default"]}
+
+    # Build final suggestions with rationales
+    for cmd, data in command_scores.items():
+        score = data["score"]
+        rationale = f"Score {score}: " + ", ".join(data["rationale_parts"])
+        suggestions.append((cmd, score, rationale))
+
+    # Sort by descending score, then alphabetically by command for ties
+    suggestions.sort(key=lambda x: (-x[1], x[0]))
+
+    return suggestions
+
+
+def build_repro_md(
+    title: str,
+    assumptions: list[str],
+    commands: list[tuple[str, int, str]],
+    needs: list[str],
+    next_steps: list[str],
+) -> str:
+    """
+    Build a reproduction markdown document with standardized structure.
+
+    Args:
+        title: Title for the reproduction document
+        assumptions: List of assumptions made
+        commands: List of (command, score, rationale) tuples
+        needs: List of environment/dependency needs
+        next_steps: List of next steps to take
+
+    Returns:
+        Formatted markdown string
+    """
+    lines = []
+
+    # Title
+    lines.append(f"# {title}")
+    lines.append("")
+
+    # Assumptions section
+    lines.append("## Assumptions")
+    lines.append("")
+    if assumptions:
+        for assumption in assumptions:
+            lines.append(f"- {assumption}")
+    else:
+        lines.append("- None specified")
+    lines.append("")
+
+    # Environment/Needs section
+    lines.append("## Environment / Needs")
+    lines.append("")
+    if needs:
+        for need in needs:
+            lines.append(f"- {need}")
+    else:
+        lines.append("- Standard development environment")
+    lines.append("")
+
+    # Steps section with table
+    lines.append("## Steps (ranked)")
+    lines.append("")
+    lines.append("| Score | Command | Why |")
+    lines.append("|-------|---------|-----|")
+
+    if commands:
+        for cmd, score, rationale in commands:
+            # Escape pipe characters in command and rationale for markdown table
+            cmd_escaped = cmd.replace("|", "\\|")
+            rationale_escaped = rationale.replace("|", "\\|")
+            lines.append(f"| {score} | `{cmd_escaped}` | {rationale_escaped} |")
+    else:
+        lines.append("| - | No commands suggested | - |")
+
+    lines.append("")
+
+    # Next Steps section
+    lines.append("## Next Steps")
+    lines.append("")
+    if next_steps:
+        for step in next_steps:
+            lines.append(f"- {step}")
+    else:
+        lines.append("- Run the suggested commands and analyze results")
+        lines.append("- Review logs for error patterns")
+        lines.append("- Adjust environment if needed")
+    lines.append("")
+
+    return "\n".join(lines)

--- a/tests/test_plan_cli.py
+++ b/tests/test_plan_cli.py
@@ -1,0 +1,335 @@
+"""Tests for the AutoRepro plan CLI command."""
+
+import os
+import subprocess
+import sys
+import tempfile
+from unittest.mock import patch
+
+from autorepro.cli import main
+
+
+class TestPlanCLIArguments:
+    """Test plan command argument handling."""
+
+    def test_missing_desc_and_file_exit_2(self, capsys):
+        """Test that missing --desc and --file returns exit code 2."""
+        with patch("sys.argv", ["autorepro", "plan"]):
+            exit_code = main()
+
+        assert exit_code == 2
+        captured = capsys.readouterr()
+        error_output = captured.out + captured.err
+        assert "one of the arguments --desc --file is required" in error_output
+
+    def test_both_desc_and_file_exit_2(self, capsys):
+        """Test that providing both --desc and --file returns exit code 2."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("test issue")
+            temp_file = f.name
+
+        try:
+            with patch("sys.argv", ["autorepro", "plan", "--desc", "test", "--file", temp_file]):
+                exit_code = main()
+
+            assert exit_code == 2
+            captured = capsys.readouterr()
+            error_output = captured.out + captured.err
+            assert "not allowed with argument" in error_output
+        finally:
+            os.unlink(temp_file)
+
+    def test_invalid_file_exit_1(self, capsys):
+        """Test that non-existent file returns exit code 1."""
+        with patch("sys.argv", ["autorepro", "plan", "--file", "nonexistent.txt"]):
+            exit_code = main()
+
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        error_output = captured.out + captured.err
+        assert "Error reading file" in error_output
+
+
+class TestPlanCLIBasicFunctionality:
+    """Test basic plan command functionality."""
+
+    def test_desc_writes_repro_md_with_pytest(self, tmp_path, monkeypatch):
+        """Test --desc writes repro.md containing pytest -q."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create a python project indicator
+        (tmp_path / "pyproject.toml").write_text("[build-system]")
+
+        with patch("sys.argv", ["autorepro", "plan", "--desc", "pytest tests failing"]):
+            exit_code = main()
+
+        assert exit_code == 0
+
+        # Check repro.md was created
+        repro_file = tmp_path / "repro.md"
+        assert repro_file.exists()
+
+        content = repro_file.read_text()
+        assert "pytest -q" in content
+        assert "| Score | Command | Why |" in content
+
+    def test_file_input_works(self, tmp_path, monkeypatch):
+        """Test --file reads from file and generates plan."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create input file
+        input_file = tmp_path / "issue.txt"
+        input_file.write_text("npm test failing with jest")
+
+        with patch("sys.argv", ["autorepro", "plan", "--file", str(input_file)]):
+            exit_code = main()
+
+        assert exit_code == 0
+
+        # Check repro.md was created
+        repro_file = tmp_path / "repro.md"
+        assert repro_file.exists()
+
+        content = repro_file.read_text()
+        assert "jest" in content.lower() or "npm test" in content
+
+    def test_custom_output_path(self, tmp_path, monkeypatch):
+        """Test --out specifies custom output path."""
+        monkeypatch.chdir(tmp_path)
+
+        custom_path = tmp_path / "custom_repro.md"
+
+        with patch(
+            "sys.argv", ["autorepro", "plan", "--desc", "test issue", "--out", str(custom_path)]
+        ):
+            exit_code = main()
+
+        assert exit_code == 0
+        assert custom_path.exists()
+        assert not (tmp_path / "repro.md").exists()
+
+
+class TestPlanCLIOverwriteBehavior:
+    """Test plan command file overwrite behavior."""
+
+    def test_existing_file_without_force_no_overwrite(self, tmp_path, monkeypatch, capsys):
+        """Test existing file without --force doesn't overwrite and returns exit 0."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create existing repro.md
+        existing_file = tmp_path / "repro.md"
+        existing_content = "# Existing content"
+        existing_file.write_text(existing_content)
+
+        with patch("sys.argv", ["autorepro", "plan", "--desc", "new issue"]):
+            exit_code = main()
+
+        assert exit_code == 0
+
+        # File should not be overwritten
+        assert existing_file.read_text() == existing_content
+
+        # Should print message about existing file
+        captured = capsys.readouterr()
+        assert "repro.md exists; use --force to overwrite" in captured.out
+
+    def test_existing_file_with_force_overwrites(self, tmp_path, monkeypatch, capsys):
+        """Test existing file with --force gets overwritten."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create existing repro.md
+        existing_file = tmp_path / "repro.md"
+        existing_file.write_text("# Old content")
+
+        with patch("sys.argv", ["autorepro", "plan", "--desc", "new pytest issue", "--force"]):
+            exit_code = main()
+
+        assert exit_code == 0
+
+        # File should be overwritten
+        new_content = existing_file.read_text()
+        assert "# Old content" not in new_content
+        assert "pytest" in new_content.lower()
+
+        # Should print the output path
+        captured = capsys.readouterr()
+        assert "repro.md" in captured.out
+
+
+class TestPlanCLILanguageDetection:
+    """Test plan command integration with language detection."""
+
+    def test_python_project_detected_in_needs(self, tmp_path, monkeypatch):
+        """Test Python project detection appears in Environment/Needs section."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create Python project indicators
+        (tmp_path / "pyproject.toml").write_text("[build-system]")
+
+        with patch("sys.argv", ["autorepro", "plan", "--desc", "tests failing"]):
+            exit_code = main()
+
+        assert exit_code == 0
+
+        content = (tmp_path / "repro.md").read_text()
+
+        # Should mention Python in assumptions and needs
+        assert "python" in content.lower()
+        assert "## Environment / Needs" in content
+        assert "Python 3.7+" in content
+
+    def test_node_project_detected_in_needs(self, tmp_path, monkeypatch):
+        """Test Node.js project detection appears in Environment/Needs section."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create Node.js project indicators
+        (tmp_path / "package.json").write_text('{"name": "test"}')
+
+        with patch("sys.argv", ["autorepro", "plan", "--desc", "npm test failing"]):
+            exit_code = main()
+
+        assert exit_code == 0
+
+        content = (tmp_path / "repro.md").read_text()
+
+        # Should mention Node in assumptions and needs
+        assert "node" in content.lower()
+        assert "## Environment / Needs" in content
+        assert "Node.js" in content
+
+    def test_mixed_languages_detected(self, tmp_path, monkeypatch):
+        """Test multiple languages detected and mentioned."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create indicators for multiple languages
+        (tmp_path / "pyproject.toml").write_text("[build-system]")
+        (tmp_path / "package.json").write_text('{"name": "test"}')
+
+        with patch("sys.argv", ["autorepro", "plan", "--desc", "tests failing"]):
+            exit_code = main()
+
+        assert exit_code == 0
+
+        content = (tmp_path / "repro.md").read_text()
+
+        # Should mention both languages
+        content_lower = content.lower()
+        assert "python" in content_lower or "node" in content_lower
+        assert "based on detected files" in content
+
+
+class TestPlanCLIMaxCommands:
+    """Test --max flag functionality."""
+
+    def test_max_limits_command_count(self, tmp_path, monkeypatch):
+        """Test --max limits the number of suggested commands."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create Python project to get multiple suggestions
+        (tmp_path / "pyproject.toml").write_text("[build-system]")
+
+        with patch(
+            "sys.argv",
+            ["autorepro", "plan", "--desc", "pytest tox jest tests failing", "--max", "2"],
+        ):
+            exit_code = main()
+
+        assert exit_code == 0
+
+        content = (tmp_path / "repro.md").read_text()
+
+        # Count table rows (excluding header)
+        lines = content.split("\n")
+        table_rows = [
+            line
+            for line in lines
+            if line.startswith("| ")
+            and "Score" not in line
+            and "---" not in line
+            and line.count("|") >= 3
+        ]
+
+        # Should have at most 2 command rows (excluding empty command row)
+        command_rows = [
+            row for row in table_rows if "`" in row
+        ]  # Rows with actual commands (in backticks)
+        assert len(command_rows) <= 2
+
+
+class TestPlanCLIFormatFlag:
+    """Test --format flag functionality."""
+
+    def test_json_format_fallback_message(self, tmp_path, monkeypatch, capsys):
+        """Test --format json prints fallback message and generates md."""
+        monkeypatch.chdir(tmp_path)
+
+        with patch("sys.argv", ["autorepro", "plan", "--desc", "test issue", "--format", "json"]):
+            exit_code = main()
+
+        assert exit_code == 0
+
+        # Should print fallback message
+        captured = capsys.readouterr()
+        assert "json output not implemented yet; generating md" in captured.out
+
+        # Should still create markdown file
+        repro_file = tmp_path / "repro.md"
+        assert repro_file.exists()
+
+        content = repro_file.read_text()
+        assert "# Test Issue" in content  # Should be markdown format
+
+
+class TestPlanCLIIntegration:
+    """Integration tests using subprocess."""
+
+    def test_plan_help_via_subprocess(self):
+        """Test plan help using subprocess."""
+        result = subprocess.run(
+            [sys.executable, "-m", "autorepro.cli", "plan", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "--desc" in result.stdout
+        assert "--file" in result.stdout
+        assert "--force" in result.stdout
+        assert "--max" in result.stdout
+        assert "--format" in result.stdout
+
+    def test_plan_missing_args_via_subprocess(self):
+        """Test plan with missing arguments via subprocess."""
+        result = subprocess.run(
+            [sys.executable, "-m", "autorepro.cli", "plan"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        assert "required" in (result.stdout + result.stderr).lower()
+
+    def test_plan_success_via_subprocess(self, tmp_path):
+        """Test successful plan generation via subprocess."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "autorepro.cli",
+                "plan",
+                "--desc",
+                "pytest failing",
+                "--out",
+                "test_plan.md",
+            ],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "test_plan.md" in result.stdout
+
+        # Check file was created
+        plan_file = tmp_path / "test_plan.md"
+        assert plan_file.exists()
+
+        content = plan_file.read_text()
+        assert "# Pytest Failing" in content

--- a/tests/test_plan_core.py
+++ b/tests/test_plan_core.py
@@ -1,0 +1,245 @@
+"""Tests for the AutoRepro planner core functions."""
+
+from autorepro.planner import build_repro_md, extract_keywords, suggest_commands
+
+
+class TestExtractKeywords:
+    """Test the extract_keywords function."""
+
+    def test_empty_string(self):
+        """Test keyword extraction from empty string."""
+        result = extract_keywords("")
+        assert result == set()
+
+    def test_basic_keywords(self):
+        """Test extraction of basic keywords."""
+        text = "pytest tests failing on CI with npm"
+        result = extract_keywords(text)
+        expected = {"pytest", "tests", "failing", "ci", "npm"}
+        assert result == expected
+
+    def test_stopword_filtering(self):
+        """Test that stopwords are filtered out."""
+        text = "the tests are failing and we need to fix them"
+        result = extract_keywords(text)
+        # Should exclude: the, are, and, we, to, them
+        expected = {"tests", "failing", "need", "fix"}
+        assert result == expected
+
+    def test_dev_terms_preserved(self):
+        """Test that developer terms are preserved even if they would be stopwords."""
+        text = "go test with make and jest"
+        result = extract_keywords(text)
+        expected = {"go", "test", "make", "jest"}
+        assert result == expected
+
+    def test_short_tokens_filtered(self):
+        """Test that very short tokens are filtered out."""
+        text = "a pytest b test c npm d"
+        result = extract_keywords(text)
+        expected = {"pytest", "test", "npm"}
+        assert result == expected
+
+    def test_case_insensitive(self):
+        """Test that extraction is case insensitive."""
+        text = "PyTest TESTS Failing CI"
+        result = extract_keywords(text)
+        expected = {"pytest", "tests", "failing", "ci"}
+        assert result == expected
+
+
+class TestSuggestCommands:
+    """Test the suggest_commands function."""
+
+    def test_python_language_detection(self):
+        """Test command suggestions for Python projects."""
+        keywords = {"test", "pytest"}
+        detected_langs = ["python"]
+
+        suggestions = suggest_commands(keywords, detected_langs)
+
+        # Should have pytest suggestions at top
+        assert len(suggestions) > 0
+        top_command = suggestions[0][0]
+        assert "pytest" in top_command
+
+        # Check scores are integers and rationales are strings
+        for _, score, rationale in suggestions:
+            assert isinstance(score, int)
+            assert isinstance(rationale, str)
+            assert "Score" in rationale
+
+    def test_node_language_detection(self):
+        """Test command suggestions for Node.js projects."""
+        keywords = {"test", "npm"}
+        detected_langs = ["node"]
+
+        suggestions = suggest_commands(keywords, detected_langs)
+
+        # Should have npm test suggestions
+        npm_commands = [cmd for cmd, _, _ in suggestions if "npm test" in cmd]
+        assert len(npm_commands) > 0
+
+    def test_mixed_languages(self):
+        """Test suggestions for projects with multiple languages."""
+        keywords = {"test", "pytest", "jest"}
+        detected_langs = ["python", "javascript"]
+
+        suggestions = suggest_commands(keywords, detected_langs)
+
+        # Should have suggestions for both languages
+        python_cmds = [cmd for cmd, _, _ in suggestions if "pytest" in cmd]
+        js_cmds = [cmd for cmd, _, _ in suggestions if "jest" in cmd or "npm" in cmd]
+
+        assert len(python_cmds) > 0
+        assert len(js_cmds) > 0
+
+    def test_no_languages_conservative_defaults(self):
+        """Test that conservative defaults are provided when no languages detected."""
+        keywords = {"failing"}
+        detected_langs = []
+
+        suggestions = suggest_commands(keywords, detected_langs)
+
+        assert len(suggestions) > 0
+        # Should have some basic test commands
+        commands = [cmd for cmd, _, _ in suggestions]
+        assert any("pytest" in cmd for cmd in commands) or any(
+            "npm test" in cmd for cmd in commands
+        )
+
+    def test_scoring_descending_order(self):
+        """Test that suggestions are sorted by descending score."""
+        keywords = {"pytest", "tests", "ci"}
+        detected_langs = ["python"]
+
+        suggestions = suggest_commands(keywords, detected_langs)
+
+        # Check scores are in descending order
+        scores = [score for _, score, _ in suggestions]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_pytest_preferred_over_python(self):
+        """Test that pytest -q is preferred over python -m pytest -q."""
+        keywords = {"pytest", "test"}
+        detected_langs = ["python"]
+
+        suggestions = suggest_commands(keywords, detected_langs)
+
+        # Find pytest commands
+        pytest_direct = None
+        pytest_module = None
+
+        for cmd, score, _ in suggestions:
+            if cmd == "pytest -q":
+                pytest_direct = score
+            elif cmd == "python -m pytest -q":
+                pytest_module = score
+
+        # pytest -q should have higher or equal score to python -m pytest -q
+        assert pytest_direct is not None
+        assert pytest_module is not None
+        assert pytest_direct >= pytest_module
+
+    def test_deterministic_ordering_with_tie_breaking(self):
+        """Test that commands with same score are ordered alphabetically."""
+        # Create a scenario where we might have score ties
+        keywords = {"test"}
+        detected_langs = ["python"]
+
+        suggestions = suggest_commands(keywords, detected_langs)
+
+        # Group by score and check alphabetical ordering within groups
+        score_groups = {}
+        for cmd, score, _ in suggestions:
+            if score not in score_groups:
+                score_groups[score] = []
+            score_groups[score].append(cmd)
+
+        # Check each score group is alphabetically ordered
+        for _, commands in score_groups.items():
+            assert commands == sorted(commands)
+
+
+class TestBuildReproMd:
+    """Test the build_repro_md function."""
+
+    def test_all_five_sections_present(self):
+        """Test that all five required sections are present."""
+        title = "Test Issue"
+        assumptions = ["Python available"]
+        commands = [("pytest -q", 20, "Test command")]
+        needs = ["Python 3.7+"]
+        next_steps = ["Run tests"]
+
+        result = build_repro_md(title, assumptions, commands, needs, next_steps)
+
+        # Check all required sections are present
+        assert "# Test Issue" in result
+        assert "## Assumptions" in result
+        assert "## Environment / Needs" in result
+        assert "## Steps (ranked)" in result
+        assert "## Next Steps" in result
+
+    def test_table_format_in_steps_section(self):
+        """Test that steps section contains properly formatted table."""
+        title = "Test"
+        commands = [
+            ("pytest -q", 30, "High priority test"),
+            ("npm test -s", 20, "Node test"),
+        ]
+
+        result = build_repro_md(title, [], commands, [], [])
+
+        # Check table headers
+        assert "| Score | Command | Why |" in result
+        assert "|-------|---------|-----|" in result
+
+        # Check table rows with backticks around commands
+        assert "| 30 | `pytest -q` | High priority test |" in result
+        assert "| 20 | `npm test -s` | Node test |" in result
+
+    def test_empty_lists_handled_gracefully(self):
+        """Test that empty lists are handled with defaults."""
+        title = "Empty Test"
+
+        result = build_repro_md(title, [], [], [], [])
+
+        # Should have default content for empty sections
+        assert "- None specified" in result  # assumptions
+        assert "- Standard development environment" in result  # needs
+        assert "- Run the suggested commands" in result  # next steps
+        assert "| - | No commands suggested | - |" in result  # empty commands
+
+    def test_pipe_character_escaping(self):
+        """Test that pipe characters in commands/rationales are escaped."""
+        title = "Pipe Test"
+        commands = [("echo 'test|data'", 10, "Command with | pipe")]
+
+        result = build_repro_md(title, [], commands, [], [])
+
+        # Pipes should be escaped in table
+        assert "| 10 | `echo 'test\\|data'` | Command with \\| pipe |" in result
+
+    def test_markdown_structure_stability(self):
+        """Test that markdown structure is consistent and diff-friendly."""
+        title = "Structure Test"
+        assumptions = ["Assumption 1", "Assumption 2"]
+        commands = [("cmd1", 10, "reason1")]
+        needs = ["Need 1"]
+        next_steps = ["Step 1", "Step 2"]
+
+        result = build_repro_md(title, assumptions, commands, needs, next_steps)
+
+        # Check consistent spacing (empty lines between sections)
+        lines = result.split("\n")
+
+        # Title should be followed by empty line
+        title_idx = next(i for i, line in enumerate(lines) if line == "# Structure Test")
+        assert lines[title_idx + 1] == ""
+
+        # Sections should be separated by empty lines
+        assert "## Assumptions" in result
+        assert "## Environment / Needs" in result
+        assert "## Steps (ranked)" in result
+        assert "## Next Steps" in result


### PR DESCRIPTION
 What: Add autorepro plan command that generates structured reproduction plans from issue descriptions.

  Why: Transforms issue text into actionable repro steps with prioritized commands based on project language detection and keyword
  analysis.

  How:
  - New autorepro/planner.py module with 4 pure functions (normalize, extract_keywords, suggest_commands, build_repro_md)
  - CLI integration with flags: --desc/--file (mutually exclusive), --out, --force, --max, --format
  - Language detection integration for intelligent command weighting
  - Comprehensive test coverage (34 new tests)

  Examples:
  $ autorepro plan --desc "pytest tests failing on CI"
  repro.md

  $ autorepro plan --file issue.txt --max 3 --force
  repro.md

  Testing: 107/107 tests pass, all pre-commit hooks pass, deterministic ordering verified.